### PR TITLE
Timeout Fix

### DIFF
--- a/tap_domo/client.py
+++ b/tap_domo/client.py
@@ -4,7 +4,13 @@ import json
 
 class DOMOClient:
     def __init__(self, client_id: str, client_secret: str):
+        self.client_id = client_id
+        self.client_secret = client_secret
         self.domo = Domo(client_id, client_secret)
+
+    def reconnect(self):
+        self.domo = Domo(self.client_id, self.client_secret)
+        return
 
     def records_query(
         self,


### PR DESCRIPTION
# Description :: User Story

The speed of DOMO's response is very variable and a certain limit size could be very fast for one set versus another or one time of day versus another.  Without making the limit size very small, there is the chance that the DOMO api will timeout on a request.

There is now a try catch block that will catch query based errors for timeouts or revalidations.  This block will continue back into the batch that failed.  If the tap fails for any other reason, this will not catch that and should be addressed separately.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Breaking Change
- [ ] Testing
- [ ] Documentation

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes

