### PR TITLE
Modify Bookmarking to prevent break

### DIFF
--- a/tap_domo/streams.py
+++ b/tap_domo/streams.py
@@ -41,24 +41,17 @@ class Stream:
                     self.replication_key,
                     bookmark,
                 )
-                for record in response:
-                    record.pop("index")
-                    for key in record:
-                        if record[key] == "":
-                            record[key] = None
-                    record_count += 1
-                    yield record
+
+                if len(response) > 0:
+                    for record in response:
+                        record.pop("index")
+                        for key in record:
+                            if record[key] == "":
+                                record[key] = None
+                        record_count += 1
+                        yield record
 
                 batch += 1
-                if self.replication_key != "":
-                    singer.write_bookmark(
-                        self.state,
-                        self.tap_stream_id,
-                        self.replication_key,
-                        record[self.replication_key],
-                    )
-                    singer.write_state(self.state)
-                    
                 offset += limit
 
             except Exception as e:

--- a/tap_domo/sync.py
+++ b/tap_domo/sync.py
@@ -52,13 +52,13 @@ def sync(config, state, catalog):
                 )
                 record_count += 1
 
+                singer.write_bookmark(
+                    state, tap_stream_id, replication_key, record[replication_key]
+                )
+
             # If there is a Bookmark or state based key to store
-            try:
-                if replication_key != "":
-                    singer.write_bookmark(
-                        state, tap_stream_id, replication_key, record[replication_key]
-                    )
-            except:
+            
+            if record_count == 0:
                 LOGGER.info(f'No records to update bookmark')
 
             stream_stop = time.perf_counter()


### PR DESCRIPTION
# Description :: Connector Issues

With the two different bookmarking keys across the stream there was an occasion that if no records were updated since the last sync it would present a BROKEN PIPE error.  This would also reset the bookmarking and trigger a backfill pull.  By making sure this bookmarking only happens if new records are present will fix this issue.

## Type of Change

- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor
- [ ] Breaking Change
- [ ] Testing
- [ ] Documentation

## Environment and Dependencies

- [ ] Packages Added
- [ ] Packages Updated
- [ ] Packages Removed
- [x] No Changes
