### PR TITLE
Add Price Unit to Inventory Schema

### DIFF
--- a/tap_domo/schemas/inventory.json
+++ b/tap_domo/schemas/inventory.json
@@ -143,6 +143,9 @@
     "product_sku": {
       "type": ["string", "null"]
     },
+    "priceunit": {
+      "type": ["string", "null"]
+    },
     "harvest_date": {
       "type": ["string", "null"]
     },


### PR DESCRIPTION
Treez updated the DOMO Inventory Endpoint with an addition column.

This column was also manually added to Bigquery via the UI